### PR TITLE
Include cnxdb/schema/*.* in the package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,6 @@
 include *.txt *.rst
 recursive-include cnxdb/*-sql *.*
+recursive-include cnxdb/schema *.*
 recursive-include cnxdb/migrations *.py
 recursive-include cnxdb/tests/**/data *.*
 recursive-include docs *.*


### PR DESCRIPTION
To fix this error:

```
Traceback (most recent call last):
  File "/home/travis/build/Connexions/cnx-archive/cnxarchive/tests/transforms/test_resolvers.py", line 295, in setUp
    self.fixture.setUp()
  File "/home/travis/build/Connexions/cnx-archive/cnxarchive/tests/testing.py", line 74, in wrapped
    return method(self, cursor, *args, **kwargs)
  File "/home/travis/build/Connexions/cnx-archive/cnxarchive/tests/testing.py", line 176, in setUp
    super(DataFixture, self).setUp()
  File "/home/travis/build/Connexions/cnx-archive/cnxarchive/tests/testing.py", line 159, in setUp
    init_db(self._settings[config.CONNECTION_STRING], True)
  File "/home/travis/build/Connexions/cnx-archive/.eggs/cnx_db-0.2.0-py2.7.egg/cnxdb/init/main.py", line 53, in init_db
    for schema_part in get_schema(SCHEMA_DIR):
  File "/home/travis/build/Connexions/cnx-archive/.eggs/cnx_db-0.2.0-py2.7.egg/cnxdb/init/manifest.py", line 58, in get_schema
    schema_manifest = _read_schema_manifest(manifest_filepath)
  File "/home/travis/build/Connexions/cnx-archive/.eggs/cnx_db-0.2.0-py2.7.egg/cnxdb/init/manifest.py", line 16, in _read_schema_manifest
    with open(os.path.abspath(manifest_filepath), 'r') as fp:
IOError: [Errno 2] No such file or directory: '/home/travis/build/Connexions/cnx-archive/.eggs/cnx_db-0.2.0-py2.7.egg/cnxdb/schema/manifest.json'
```